### PR TITLE
Stop using secrets and internal resource classes for open-source

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ parameters:
   docker_img_version:
     # Docker image version for running tests.
     type: string
-    default: "6f8d92b-main"
+    default: "dcf0f9f-main"
 
 workflows:
   test-jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,17 +4,13 @@ parameters:
   docker_img_version:
     # Docker image version for running tests.
     type: string
-    default: "cbd47ce-main"
+    default: "6f8d92b-main"
 
 workflows:
   test-jobs:
     jobs:
-      - format:
-          context:
-            - ghcr-auth
-      - py-tests:
-          context:
-            - ghcr-auth
+      - format
+      - py-tests
 
 commands:
   save-worker-test-results:
@@ -31,11 +27,8 @@ commands:
 jobs:
   format:
     docker:
-      - image: ghcr.io/alignmentresearch/lp-cleanba:<< pipeline.parameters.docker_img_version >>
-        auth:
-          username: "$GHCR_DOCKER_USER"
-          password: "$GHCR_DOCKER_TOKEN"
-    resource_class: alignmentresearch/small
+      - image: ghcr.io/alignmentresearch/train-learned-planner:<< pipeline.parameters.docker_img_version >>
+    resource_class: small
     working_directory: /workspace
     steps:
       - recursive-checkout
@@ -48,11 +41,8 @@ jobs:
 
   py-tests:
     docker:
-      - image: ghcr.io/alignmentresearch/lp-cleanba:<< pipeline.parameters.docker_img_version >>
-        auth:
-          username: "$GHCR_DOCKER_USER"
-          password: "$GHCR_DOCKER_TOKEN"
-    resource_class: alignmentresearch/medium
+      - image: ghcr.io/alignmentresearch/train-learned-planner:<< pipeline.parameters.docker_img_version >>
+    resource_class: medium
     working_directory: /workspace
     steps:
       - recursive-checkout

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-APPLICATION_NAME ?= lp-cleanba
+APPLICATION_NAME ?= train-learned-planner
 APPLICATION_URL ?= ghcr.io/alignmentresearch/${APPLICATION_NAME}
 DOCKERFILE ?= Dockerfile
 
@@ -16,6 +16,7 @@ default: release/main
 RELEASE_PREFIX ?= latest
 BUILD_PREFIX ?= $(shell git rev-parse --short HEAD)
 
+# NOTE: to bootstrap `pip-tools` image, comment out the `requirements.txt` dependency here and run `make release/main-pip-tools`
 .build/with-reqs/${BUILD_PREFIX}/%: requirements.txt
 	mkdir -p .build/with-reqs/${BUILD_PREFIX}
 	docker pull "${APPLICATION_URL}:${BUILD_PREFIX}-$*" || true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Train Learned Planners
 
-This repository contains training code for the paper ["Planning behavior in a recurrent neural network that plays Sokoban"](https://openreview.net/forum?id=T9sB3S2hok), from the ICML 2024 Mechanistic Interpretability Workshop. ([OpenReview](https://openreview.net/forum?id=T9sB3S2hok)) (arXiv TODO)
+This repository contains training code for the paper ["Planning behavior in a recurrent neural network that plays
+Sokoban"](https://openreview.net/forum?id=T9sB3S2hok), from the ICML 2024 Mechanistic Interpretability Workshop.
+([OpenReview](https://openreview.net/forum?id=T9sB3S2hok)) (arXiv TODO). It is based on
+[CleanRL](https://github.com/vwxyzjn/cleanba).
 
 The [learned-planners repository](TODO: link) lets you download and use the trained neural networks. If you just want to do interpretability, you should go there.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,17 +35,18 @@ exclude = [
 reportPrivateImportUsage = "warning"
 
 [project]
-name = "lp-cleanba"
+name = "train-learned-planner"
 version = "1.0.0"
-description = ""
+description = "Code for training a DRC planner on Sokoban"
 authors = [
-    {name="Costa Huang", email="costa.huang@outlook.com"},
     {name="Adrià Garriga-Alonso", email="adria@far.ai"},
+    {name="Mohammad Taufeeque", email="taufeeque@far.ai"},
+    {name="Costa Huang", email="costa.huang@outlook.com"},
 ]
 readme = "README.md"
 
 dependencies = [
-    "tyro ~=0.5.5",
+    "rich ~= 13.7",
     "tensorboard ~=2.12.0",
     "flax ~=0.8.0",
     "optax ~=0.1.4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,8 +16,6 @@ absl-py==2.1.0
     #   tensorflow-probability
 aiosignal==1.3.1
     # via ray
-appdirs==1.4.4
-    # via wandb
 attrs==23.2.0
     # via
     #   jsonschema
@@ -35,9 +33,9 @@ charset-normalizer==3.3.2
 chex==0.1.86
     # via
     #   distrax
-    #   lp-cleanba (pyproject.toml)
     #   optax
     #   rlax
+    #   train-learned-planner (pyproject.toml)
 click==8.1.7
     # via
     #   ray
@@ -72,21 +70,19 @@ dm-tree==0.1.8
     #   tensorflow-probability
 docker-pycreds==0.4.0
     # via wandb
-docstring-parser==0.16
-    # via tyro
 etils[epath,epy]==1.7.0
     # via orbax-checkpoint
 exceptiongroup==1.2.0
     # via pytest
 farconf @ git+https://github.com/AlignmentResearch/farconf.git
-    # via lp-cleanba (pyproject.toml)
+    # via train-learned-planner (pyproject.toml)
 filelock==3.13.3
     # via
     #   huggingface-hub
     #   ray
     #   virtualenv
 flax==0.8.2
-    # via lp-cleanba (pyproject.toml)
+    # via train-learned-planner (pyproject.toml)
 fonttools==4.53.0
     # via matplotlib
 frozenlist==1.4.1
@@ -103,7 +99,7 @@ gitdb==4.0.11
     # via gitpython
 gitpython==3.1.43
     # via
-    #   lp-cleanba (pyproject.toml)
+    #   train-learned-planner (pyproject.toml)
     #   wandb
 google-auth==2.29.0
     # via
@@ -114,11 +110,11 @@ google-auth-oauthlib==1.0.0
 grpcio==1.62.1
     # via tensorboard
 gym==0.23.1
-    # via lp-cleanba (pyproject.toml)
+    # via train-learned-planner (pyproject.toml)
 gym-notices==0.0.8
     # via gym
 huggingface-hub==0.12.1
-    # via lp-cleanba (pyproject.toml)
+    # via train-learned-planner (pyproject.toml)
 identify==2.5.35
     # via pre-commit
 idna==3.6
@@ -159,7 +155,7 @@ markdown-it-py==3.0.0
 markupsafe==2.1.5
     # via werkzeug
 matplotlib==3.9.0
-    # via lp-cleanba (pyproject.toml)
+    # via train-learned-planner (pyproject.toml)
 mdurl==0.1.2
     # via markdown-it-py
 ml-dtypes==0.4.0
@@ -168,14 +164,14 @@ ml-dtypes==0.4.0
     #   jaxlib
     #   tensorstore
 moviepy==1.0.3
-    # via lp-cleanba (pyproject.toml)
+    # via train-learned-planner (pyproject.toml)
 msgpack==1.0.8
     # via
     #   flax
     #   orbax-checkpoint
     #   ray
 names-generator==0.1.0
-    # via lp-cleanba (pyproject.toml)
+    # via train-learned-planner (pyproject.toml)
 nest-asyncio==1.6.0
     # via orbax-checkpoint
 nodeenv==1.8.0
@@ -215,13 +211,13 @@ numpy==1.26.4
 oauthlib==3.2.2
     # via requests-oauthlib
 opencv-python==4.7.0.72
-    # via lp-cleanba (pyproject.toml)
+    # via train-learned-planner (pyproject.toml)
 opt-einsum==3.3.0
     # via jax
 optax==0.1.9
     # via
     #   flax
-    #   lp-cleanba (pyproject.toml)
+    #   train-learned-planner (pyproject.toml)
 orbax-checkpoint==0.5.9
     # via flax
 packaging==24.0
@@ -233,18 +229,18 @@ packaging==24.0
     #   tensorboardx
 pandas==2.2.2
     # via ray
-pathtools==0.1.2
-    # via wandb
 pillow==10.3.0
     # via
     #   imageio
     #   matplotlib
 platformdirs==4.2.0
-    # via virtualenv
+    # via
+    #   virtualenv
+    #   wandb
 pluggy==1.4.0
     # via pytest
 pre-commit==3.6.2
-    # via lp-cleanba (pyproject.toml)
+    # via train-learned-planner (pyproject.toml)
 proglog==0.1.10
     # via moviepy
 protobuf==4.25.3
@@ -269,9 +265,9 @@ pygments==2.17.2
 pyparsing==3.1.2
     # via matplotlib
 pyright==1.1.357
-    # via lp-cleanba (pyproject.toml)
+    # via train-learned-planner (pyproject.toml)
 pytest==7.3.2
-    # via lp-cleanba (pyproject.toml)
+    # via train-learned-planner (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via
     #   matplotlib
@@ -289,7 +285,7 @@ pyyaml==6.0.1
     #   ray
     #   wandb
 ray[tune]==2.11.0
-    # via lp-cleanba (pyproject.toml)
+    # via train-learned-planner (pyproject.toml)
 referencing==0.35.0
     # via
     #   jsonschema
@@ -307,9 +303,9 @@ requests-oauthlib==2.0.0
 rich==13.7.1
     # via
     #   flax
-    #   tyro
+    #   train-learned-planner (pyproject.toml)
 rlax==0.1.6
-    # via lp-cleanba (pyproject.toml)
+    # via train-learned-planner (pyproject.toml)
 rpds-py==0.18.0
     # via
     #   jsonschema
@@ -317,7 +313,7 @@ rpds-py==0.18.0
 rsa==4.9
     # via google-auth
 ruff==0.1.15
-    # via lp-cleanba (pyproject.toml)
+    # via train-learned-planner (pyproject.toml)
 scipy==1.13.0
     # via
     #   jax
@@ -326,8 +322,6 @@ sentry-sdk==1.44.1
     # via wandb
 setproctitle==1.3.3
     # via wandb
-shtab==1.7.1
-    # via tyro
 six==1.16.0
     # via
     #   docker-pycreds
@@ -336,13 +330,13 @@ six==1.16.0
 smmap==5.0.1
     # via gitdb
 tensorboard==2.12.3
-    # via lp-cleanba (pyproject.toml)
+    # via train-learned-planner (pyproject.toml)
 tensorboard-data-server==0.7.2
     # via tensorboard
 tensorboardx==2.6.2.2
     # via
-    #   lp-cleanba (pyproject.toml)
     #   ray
+    #   train-learned-planner (pyproject.toml)
 tensorflow-probability==0.24.0
     # via distrax
 tensorstore==0.1.56
@@ -373,9 +367,6 @@ typing-extensions==4.11.0
     #   huggingface-hub
     #   orbax-checkpoint
     #   typeapi
-    #   tyro
-tyro==0.5.18
-    # via lp-cleanba (pyproject.toml)
 tzdata==2024.1
     # via pandas
 urllib3==2.2.1
@@ -384,8 +375,8 @@ urllib3==2.2.1
     #   sentry-sdk
 virtualenv==20.25.1
     # via pre-commit
-wandb==0.13.11
-    # via lp-cleanba (pyproject.toml)
+wandb==0.17.4
+    # via train-learned-planner (pyproject.toml)
 werkzeug==3.0.2
     # via tensorboard
 wheel==0.43.0


### PR DESCRIPTION
Turns out it's OK to just open-source a repo that uses CircleCI. CircleCI by default:

- Builds forked pull requests (but I have disabled it)
- Doesn't pass secrets to forked pull requests

If we only manually run CI when we like a PR and it's not using the `alignmentresearch/*` classes, this should be safe.